### PR TITLE
refactor: use social icons instead of buttons

### DIFF
--- a/src/components/footer.astro
+++ b/src/components/footer.astro
@@ -14,7 +14,5 @@ import Social from './social.astro';
 
 <footer>
     <p>This is an open source learning project built to test my knowledge. If you wish to contribute check out the repo on <a href="https://github.com/matsrm/mplus-hub">GitHub</a>!</p>
-    <Social platform="twitter" username="" />
     <Social platform="github" username="matsrm" />
-    <Social platform="linkedin" username="" />
 </footer>

--- a/src/components/social.astro
+++ b/src/components/social.astro
@@ -1,14 +1,22 @@
 ---
 const { platform, username } = Astro.props;
 ---
-<a href={`https://www.${platform}.com/${username}`}>{platform}</a>
+
+<div class="social-icons">
+    <a href={`https://www.${platform}.com/${username}`} target="_blank" title={platform}>
+        <i class="fa-brands fa-github"></i>
+    </a>
+</div>
 
 <style>
     a {
         display: flex;
         padding: 0.5rem 1rem;
-        color: white;
-        background-color: #4c1d95;
+        text-decoration: none;
+    }
+
+    .social-icons {
+        font-size: 32px;
         text-decoration: none;
     }
 </style>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -6,6 +6,7 @@ const { pageTitle } = Astro.props;
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
+		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<meta name="viewport" content="width=device-width" />
 		<meta name="generator" content={Astro.generator} />


### PR DESCRIPTION
- use social icons in footer instead of buttons
- automatically generate icons and link when defining a social platform